### PR TITLE
Fix default parameters being used every time

### DIFF
--- a/main.go
+++ b/main.go
@@ -41,12 +41,12 @@ type MadnsSubConfig struct {
 func main() {
 
 	var config MadnsConfig
-	usage := *flag.Bool("h", false, "Show usage")
-	configFile := *flag.String("c", "madns-config.json", "madns JSON Config File")
+	usage := flag.Bool("h", false, "Show usage")
+	configFile := flag.String("c", "madns-config.json", "madns JSON Config File")
 	flag.Parse()
 
-	b, err := ioutil.ReadFile(configFile)
-	if err != nil || usage {
+	b, err := ioutil.ReadFile(*configFile)
+	if err != nil || *usage {
 		if err != nil {
 			log.Println(err.Error())
 		}


### PR DESCRIPTION
The `flag` library assumes that the pointers it returns will not be
dereferenced until after `Parse` is called, otherwise they always
return the default values if provided.