### PR TITLE
Fix the status code check to not fail successfully

### DIFF
--- a/slack.go
+++ b/slack.go
@@ -38,7 +38,7 @@ func sendSlackMessage(webhook string, body string) {
 
 	defer resp.Body.Close()
 
-	if resp.Status != "200" {
+	if resp.StatusCode != 200 {
 		respBody, _ := ioutil.ReadAll(resp.Body)
 		log.Printf("HTTP request failed with status %s, response %s", resp.Status, string(respBody))
 		return


### PR DESCRIPTION
Check if the status code is 200 was done the wrong way, so even a successful request will log as a failure. No loss of functionality, but a bunch of very annoying log messages.